### PR TITLE
[dependabot/config] fix: enable dependabot for bun package lock file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,18 @@ updates:
         dependency-type: production
         update-types:
           - patch
+
+  - package-ecosystem: bun
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      npm-development:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+      npm-production:
+        dependency-type: production
+        update-types:
+          - patch


### PR DESCRIPTION
bun is the package manager used for the project, so enable dependabot for it.