### PR TITLE
ci: update bundle only on release branches

### DIFF
--- a/.github/workflows/auto-bundler.yml
+++ b/.github/workflows/auto-bundler.yml
@@ -1,4 +1,4 @@
-name: Auto Package
+name: Auto Bundler
 
 on:
   pull_request:
@@ -15,13 +15,11 @@ permissions:
   pull-requests: write
 
 jobs:
-  auto-package:
-    name: Auto Package Dependabot PR
+  auto-bundler:
+    name: Auto Bundler
     runs-on: ubuntu-latest
-    # Run on Dependabot PRs or manual triggers
-    if:
-      github.actor == 'dependabot[bot]' || github.event_name ==
-      'workflow_dispatch'
+    # Run only on release branches
+    if: startsWith(github.head_ref, 'release/')
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
@@ -46,8 +44,8 @@ jobs:
       - name: Install Dependencies
         run: bun install
 
-      - name: Run Packaging
-        run: bun run package
+      - name: Run bundle
+        run: bun run bundle
 
       - name: Check for changes
         id: check-changes
@@ -64,7 +62,7 @@ jobs:
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
           git add .
-          git commit -m "chore: update package after dependency updates"
+          git commit -m "chore: update for release"
           git push
 
       - name: Add label to PR
@@ -72,7 +70,7 @@ jobs:
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr edit "$PR_URL" --add-label "auto-package"
+        run: gh pr edit "$PR_URL" --add-label "auto-bundler"
 
       - name: Add comment to PR
         if: steps.check-changes.outputs.has_changes == 'true'
@@ -84,5 +82,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '👋 I just pushed packaging updates after the dependency changes. Please verify the changes!'
+              body: '👋 I just pushed updates to the PR. Please verify the changes!'
             })

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -24,7 +24,8 @@ jobs:
   check-dist:
     name: Check dist/
     runs-on: ubuntu-latest
-
+    # Run only on release branches
+    if: startsWith(github.head_ref, 'release/')
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1

--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ the output looks like.
 If you would like to contribute to the development of this GitHub Action, see
 [docs/development.md](docs/development.md).
 
+## Releasing
+
+For maintainers looking to release a new version of this action, see
+[docs/release.md](docs/release.md) for detailed release instructions.
+
 ## How to set up the NEON_API_KEY
 
 Using the action requires adding a Neon API key to your GitHub Secrets. There

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,120 @@
+# 🚀 Releasing a New Version of the Neon Schema Diff Action
+
+This document provides step-by-step instructions for maintainers to release a
+new version of the Neon Schema Diff Action.
+
+## Prerequisites
+
+- Write access to the repository
+- Git configured with appropriate credentials
+- Node.js 21+ installed
+- Bun package manager installed
+
+## Release Process
+
+### 1. Create a Release Branch
+
+Create a new branch following the naming convention `release/X.Y.Z`:
+
+```bash
+git checkout main
+git pull origin main
+git checkout -b release/X.Y.Z
+```
+
+Replace `X.Y.Z` with the appropriate semantic version number (e.g.,
+`release/1.2.0`).
+
+### 2. Update Version Number
+
+Update the `version` attribute in `package.json`:
+
+```json
+{
+  "version": "X.Y.Z"
+}
+```
+
+### 3. Development Setup and Verification
+
+Follow the same steps described in the
+[development documentation](./development.md):
+
+#### Install Dependencies
+
+```bash
+bun install
+```
+
+#### Run Tests
+
+```bash
+bun run test
+```
+
+Ensure all tests pass before proceeding.
+
+#### Verify Action Locally
+
+```bash
+cp .env.example .env
+# Configure your environment variables in .env
+bun run local-action
+```
+
+Test the action thoroughly to ensure it works as expected with the new version.
+
+#### Package TypeScript for Distribution
+
+```bash
+bun run bundle
+```
+
+### 4. Create Pull Request
+
+1. Commit your changes:
+
+   ```bash
+   git add .
+   git commit -m "build: bump version to X.Y.Z"
+   git push origin release/X.Y.Z
+   ```
+
+2. Create a pull request from `release/X.Y.Z` to `main` branch
+3. Ensure all CI checks pass
+4. Get the pull request reviewed and approved
+5. Merge the pull request to `main`
+
+### 5. Create Git Tags
+
+After the PR is merged, create the necessary Git tags:
+
+```bash
+git checkout main
+git pull origin main
+
+# Create the specific version tag
+git tag vX.Y.Z
+git push origin vX.Y.Z
+
+# Update the major version tag (e.g., v1, v2, etc.)
+git tag -f vX
+git push origin vX --force
+```
+
+**Note**: The major version tag (e.g., `v1`) allows users to reference the
+latest version within that major release automatically.
+
+### 6. Create GitHub Release
+
+Follow the
+[GitHub documentation for creating releases](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository#creating-a-release):
+
+1. Navigate to the repository on GitHub
+2. Click **Releases** on the right side of the repository page
+3. Click **Draft a new release**
+4. Configure the release:
+   - **Choose a tag**: Select `vX.Y.Z` (the tag you just created)
+   - **Release title**: `vX.Y.Z`
+   - **Description**: Generate release notes
+5. Click **Publish release**


### PR DESCRIPTION
It's quite annoying to have PRs failing constantly because of an outdated dist folder. Actually, we need to have an updated dist folder only during releases.