### PR TITLE
ci: skip test-action on changes from forked repos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,8 @@ jobs:
   test-action:
     name: GitHub Actions Test
     runs-on: ubuntu-latest
-
+    # Run only on PRs from the same repository as this job depends on secrets
+    if: github.repository == github.event.pull_request.head.repo.full_name
     steps:
       - name: Checkout
         id: checkout


### PR DESCRIPTION
The test-action job requires Action secrets which aren't passed to jobs on workflows triggered by PRs from forked repos.