### PR TITLE
chore: supply-chain hardening — workflow permissions, lockfile-backed installs, Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,38 +5,28 @@ updates:
     directory: /
     schedule:
       interval: weekly
+      day: monday
     groups:
-      actions-minor:
+      actions-minor-patch:
         update-types:
           - minor
           - patch
-
-  - package-ecosystem: npm
-    directory: /
-    schedule:
-      interval: weekly
-    groups:
-      npm-development:
-        dependency-type: development
-        update-types:
-          - minor
-          - patch
-      npm-production:
-        dependency-type: production
-        update-types:
-          - patch
+    open-pull-requests-limit: 5
 
   - package-ecosystem: bun
     directory: /
     schedule:
       interval: weekly
+      day: monday
     groups:
-      npm-development:
+      dev-dependencies:
         dependency-type: development
-        update-types:
-          - minor
-          - patch
-      npm-production:
+        # No update-types filter — every dev-dep bump (minor, patch, and
+        # major) goes into a single weekly PR.
+      prod-dependencies-patch:
         dependency-type: production
         update-types:
           - patch
+        # Production minor and major bumps stay as individual PRs so each
+        # one gets focused review.
+    open-pull-requests-limit: 5

--- a/.github/workflows/auto-bundler.yml
+++ b/.github/workflows/auto-bundler.yml
@@ -14,8 +14,10 @@ jobs:
   auto-bundler:
     name: Auto Bundler
     runs-on: ubuntu-latest
-    # Run only on release branches
-    if: startsWith(github.head_ref, 'release/')
+    # Run only on release-branch PRs originating from this repo (not a fork)
+    if: >-
+      startsWith(github.head_ref, 'release/') &&
+      github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       # Needed for checkout and push
       contents: write

--- a/.github/workflows/auto-bundler.yml
+++ b/.github/workflows/auto-bundler.yml
@@ -8,11 +8,7 @@ on:
       - '**/bun.lock'
   workflow_dispatch:
 
-permissions:
-  # Needed for checkout and push
-  contents: write
-  # Needed for PR comments
-  pull-requests: write
+permissions: {}
 
 jobs:
   auto-bundler:
@@ -20,6 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     # Run only on release branches
     if: startsWith(github.head_ref, 'release/')
+    permissions:
+      # Needed for checkout and push
+      contents: write
+      # Needed for PR comments
+      pull-requests: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -23,8 +23,10 @@ jobs:
   check-dist:
     name: Check dist/
     runs-on: ubuntu-latest
-    # Run only on release branches
-    if: startsWith(github.head_ref, 'release/')
+    # Run only on release-branch PRs originating from this repo (not a fork)
+    if: >-
+      startsWith(github.head_ref, 'release/') &&
+      github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
     steps:

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -17,8 +17,7 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   check-dist:
@@ -26,6 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     # Run only on release branches
     if: startsWith(github.head_ref, 'release/')
+    permissions:
+      contents: read
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Install Dependencies
         id: install
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Build dist/ Directory
         id: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,13 +8,14 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   test-typescript:
     name: TypeScript Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Harden Runner
@@ -55,6 +56,8 @@ jobs:
     runs-on: ubuntu-latest
     # Run only on PRs from the same repository as this job depends on secrets
     if: github.repository == github.event.pull_request.head.repo.full_name
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         id: checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Install Dependencies
         id: install
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Check Format
         id: format-check

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,16 +10,16 @@ on:
   schedule:
     - cron: '31 7 * * 3'
 
-permissions:
-  actions: read
-  checks: write
-  contents: read
-  security-events: write
+permissions: {}
 
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
 
     strategy:
       fail-fast: false

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install Dependencies
         id: install
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Lint Codebase
         id: super-linter

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -8,15 +8,16 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
-  packages: read
-  statuses: write
+permissions: {}
 
 jobs:
   lint:
     name: Lint Codebase
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+      statuses: write
 
     steps:
       - name: Harden Runner


### PR DESCRIPTION
## Summary

Supply-chain hardening for this repo's CI configuration:

**Workflow permissions**
- Set `permissions: {}` at the workflow level on all 5 workflows so any new
  job inherits no scopes by default, then grant the minimum each existing job
  needs at the job level.
- Drop `checks: write` from `codeql-analysis.yml` — the `github/codeql-action`
  README does not list it as required (it documents `actions: read`,
  `contents: read`, `security-events: write`).

**Lockfile-backed installs**
- Switch CI installs to `bun install --frozen-lockfile` in `ci.yml`,
  `linter.yml`, and `check-dist.yml` so the lockfile is load-bearing — CI
  fails fast if `package.json` and `bun.lock` drift.
- `auto-bundler.yml` keeps plain `bun install` because its job is to update
  the lockfile after release-branch dependency bumps.

**Gate release-branch workflows to same-repo PRs**
- `auto-bundler.yml` and `check-dist.yml` previously ran when `github.head_ref` started with `release/`. `github.head_ref` is the PR source branch name, which a forker controls — a fork PR named e.g. `release/pwn` would pass the check and cause `bun install` (install-time scripts) + `bun run bundle` (the `package.json` "bundle" script) to execute attacker-controlled code on the runner. GitHub's fork-PR sandbox keeps `GITHUB_TOKEN` read-only and blocks the push step in `auto-bundler.yml`, but the code-execution steps still run before that point.
- Add `github.event.pull_request.head.repo.full_name == github.repository` to both guards. For same-repo PRs the two values match; for fork PRs they don't. The check is not spoofable by branch name or PR title — it compares GitHub-controlled repo identifiers. Same idiom used elsewhere in the Neon action repos (e.g. `create-branch-action`'s `dependabot-auto-fix` workflow).

**Dependabot config**
- Drop the redundant `npm` ecosystem block — this repo's lockfile is
  `bun.lock`, so the `bun` (beta) ecosystem is the correct one. Having both
  was producing overlapping update streams.
- Group all dev-dependency bumps (minor, patch, and major) into a single
  weekly PR. Production patches stay grouped; production minor/major remain
  individual for focused review.
- Mirror the pattern from
  [`neondatabase/mcp-server-neon#215`](https://github.com/neondatabase/mcp-server-neon/pull/215):
  `day: monday`, `open-pull-requests-limit: 5`.

**SHA-pinning**

All `uses:` references in this repo are already SHA-pinned to 40-char commit
SHAs with `# v…` annotations. Dependabot infers from this format and continues
to bump by SHA, so the new config preserves SHA-pinned PRs without an explicit
flag.

The npm semver caret syntax (`^x.y.z`) already provides upper bounds at the
next major version, satisfying the standard "cap-major" guidance for
library-style packages without requiring exact pins.

## Test plan

- [x] All five workflow YAMLs and `dependabot.yml` parse cleanly
  (`python3 -c "import yaml; yaml.safe_load(...)"`).
- [x] The new fork-spoofing guards resolve to the expected single-line expression after YAML folding:
  `startsWith(github.head_ref, 'release/') && github.event.pull_request.head.repo.full_name == github.repository`
  (verified by loading each file with PyYAML and inspecting `jobs[*].if`).
- [x] **All `uses:` references are SHA-pinned** — verified by:
  ```bash
  grep -rEn 'uses:[[:space:]]+[^[:space:]]+@[^[:space:]#]+' .github/ action.yml \
    | grep -vE 'uses:[[:space:]]+[a-zA-Z0-9._/-]+@[0-9a-f]{40}([[:space:]]|$)'
  ```
  returns no results.
- [x] `bun.lock` is committed and substantive: 1,799 lines, 876 sha512
  integrity hashes (one per package), pinning the full transitive graph.
- [x] `bun install --frozen-lockfile` ran locally against the committed
  state with **0 lockfile-drift errors** — confirms `package.json` and
  `bun.lock` are in sync and the new CI command will succeed.
- [ ] Once the next CI run completes, confirm `ci.yml`, `linter.yml`,
  `check-dist.yml`, `codeql-analysis.yml`, and `auto-bundler.yml` all
  pass with the tightened permissions and `--frozen-lockfile`.
- [ ] Confirm CodeQL still uploads SARIF after dropping `checks: write`
  (this scope was not used in `github/codeql-action`'s code path; risk
  is low).
